### PR TITLE
Prevent plugin from crashing when searching for non-existent trackId

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -1234,8 +1234,9 @@ static char kPlayerItemTimeRangesContext;
         }
     }
 
+    // nil values are not permitted in NSDictionary; use NSNull instead
     return @{
-             @"track": track,
+             @"track": track ? track : [NSNull null],
              @"index": @(idx),
              };
 }


### PR DESCRIPTION
When the user searches for a track, the track and playlist index are
returned by `findTrackById`. If a suitable track is not found, use
NSNull to represent the track, as the NSDictionary returned by this
function cannot use 'nil' values.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
