### PR TITLE
Allow removal of playlist items using track ID

### DIFF
--- a/src/ios/RmxAudioPlayer.m
+++ b/src/ios/RmxAudioPlayer.m
@@ -426,14 +426,14 @@ static char kPlayerItemTimeRangesContext;
 }
 
 - (BOOL) removeItemWithValues:(NSString*)trackIndex trackId:(NSString*)trackId {
-    if (trackIndex != nil
+    if ((id)trackIndex != [NSNull null]
         && [trackIndex integerValue] > 0
         && [trackIndex integerValue] < [self avQueuePlayer].itemsForPlayer.count
         ) {
         AudioTrack* item = [self avQueuePlayer].itemsForPlayer[[trackIndex integerValue]];
         [[self avQueuePlayer] removeItem:item];
         return YES;
-    } else if (trackId != nil && ![trackId isEqualToString:@""]) {
+    } else if ((id)trackId != [NSNull null] && ![trackId isEqualToString:@""]) {
         NSDictionary* result = [self findTrackById:trackId];
         NSInteger idx = [(NSNumber*)result[@"index"] integerValue];
         AudioTrack* track = result[@"track"];


### PR DESCRIPTION
Check for the type of null value (NSNull, as opposed to nil) emitted by
the AudioTrackRemoval object when the trackIndex or trackId is not
provided. This prevents a null trackIndex from being illegally converted
to an integer, and attempts to use the trackId instead.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
